### PR TITLE
sometimes node is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ function walk (node, handler) {
   var all = typeof handler === 'function'
   for (var pending = [node]; pending.length;) {
     node = pending.shift()
+    if (!node) continue;
     var handle = all ? handler : handler[node.type]
     if (handle && (handle(node, BREAK_TOKEN) === BREAK_TOKEN)) {
       break

--- a/test/walk.js
+++ b/test/walk.js
@@ -1,0 +1,15 @@
+var test = require('tape')
+var walk = require('../')
+var esprima = require('esprima').parse
+
+test('when node is null', function (t) {
+  t.plan(1)
+
+  var handler = {
+    MemberExpression: function (node) {}
+  }
+
+  t.doesNotThrow(function() {
+    walk(undefined, handler)
+  }, 'should not throw error')
+})


### PR DESCRIPTION
The goal of this PR is to fix an exception that was happening in the `walk` function when `node` was `undefined`